### PR TITLE
Fix error message: Trying to access array offset on false

### DIFF
--- a/Model/DashboardRow/MySQLSettings.php
+++ b/Model/DashboardRow/MySQLSettings.php
@@ -77,13 +77,14 @@ class MySQLSettings extends DashboardRow implements DashboardRowInterface
         $info = '';
         foreach ($this->defaultValues as $key => $value) {
             $currentValue = $connection->fetchRow('SHOW VARIABLES LIKE \'' . $key . '\'');
-            if (is_array($currentValue) == false) continue;
-            if ($currentValue['Value'] <= $value) {
-                $this->problems .= $key . ' lower than - or equal to the default value: '
-                    . $currentValue['Value'];
-                $this->actions .= 'Ask your hosting to tune ' . $key;
+            if (is_array($currentValue) && isset($currentValue['Value'])) {
+                if ($currentValue['Value'] <= $value) {
+                    $this->problems .= $key . ' lower than - or equal to the default value: '
+                        . $currentValue['Value'];
+                    $this->actions .= 'Ask your hosting to tune ' . $key;
+                }
+                $info .= $key . ' = ' . $currentValue['Value'] . "\n";
             }
-            $info .= $key . ' = ' . $currentValue['Value'] . "\n";
         }
 
         if ($this->problems == '') {


### PR DESCRIPTION
Tested: Magetno 2.4.7-p2, php8.3, MariaDB 10.6.19
Full error message: in var/log/exception.og: main.CRITICAL: Exception: Warning: Trying to access array offset on false in vendor/magehost/performance-dashboard/Model/DashboardRow/MySQLSettings
.php on line 80